### PR TITLE
メモリの確保を効率化させる

### DIFF
--- a/reader/eval/IsEqual.go
+++ b/reader/eval/IsEqual.go
@@ -28,25 +28,17 @@ func (i *_is_equals) Equals(sexp SExpression) bool {
 	return i.TypeId() == sexp.TypeId()
 }
 
-func (_ *_is_equals) Apply(ctx context.Context, env Environment, arguments SExpression) (SExpression, error) {
-	if "cons_cell" != arguments.TypeId() {
-		return nil, errors.New("type error")
-	}
-	argCell := arguments.(ConsCell)
+func (_ *_is_equals) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
 
-	first := argCell.GetCar()
-
-	if "cons_cell" != argCell.GetCdr().TypeId() {
-		return nil, errors.New("type error")
+	if argsLength != 2 {
+		return nil, errors.New("malformed if syntax")
 	}
 
-	second := argCell.GetCdr().(ConsCell)
+	first := args[0]
 
-	if !IsEmptyList(second.GetCdr()) {
-		return nil, errors.New("argument size error")
-	}
+	second := args[1]
 
-	return NewBool(first.Equals(second.GetCar())), nil
+	return NewBool(first.Equals(second)), nil
 }
 
 func NewIsEq() SExpression {

--- a/reader/eval/and.go
+++ b/reader/eval/and.go
@@ -25,22 +25,12 @@ func (a _and) Equals(sexp SExpression) bool {
 	return a.TypeId() == sexp.TypeId()
 }
 
-func (_ _and) Apply(ctx context.Context, env Environment, args SExpression) (SExpression, error) {
-
-	if IsEmptyList(args) {
-		return NewBool(true), nil
-	}
-
-	arr, err := ToArray(args)
-
-	if err != nil {
-		return nil, err
-	}
+func (_ _and) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
 
 	evaluatedElm := NewConsCell(NewNil(), NewNil()).(SExpression)
 
-	for i := 0; i < len(arr); i++ {
-		evaluatedElm, err = Eval(ctx, arr[i], env)
+	for i := uint64(0); i < argsLength; i++ {
+		evaluatedElm, err := Eval(ctx, args[i], env)
 		if err != nil {
 			return nil, err
 		}

--- a/reader/eval/apply.go
+++ b/reader/eval/apply.go
@@ -27,17 +27,20 @@ func (a *_apply) Equals(sexp SExpression) bool {
 	return a.TypeId() == sexp.TypeId()
 }
 
-func (_ *_apply) Apply(ctx context.Context, env Environment, args SExpression) (SExpression, error) {
-	arr, err := ToArray(args)
+func (_ *_apply) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
+	if argsLength != 2 {
+		return nil, errors.New("malformed apply")
+	}
+	car := args[0]
+	cdr := args[1]
+
+	cdrArr, size, err := ToArray(cdr)
+
 	if err != nil {
 		return nil, err
 	}
-	if len(arr) != 2 {
-		return nil, errors.New("malformed apply")
-	}
-	car := arr[0]
-	cdr := arr[1]
-	return car.(Callable).Apply(ctx, env, cdr)
+
+	return car.(Callable).Apply(ctx, env, cdrArr, size)
 }
 
 func NewApply() SExpression {

--- a/reader/eval/begin.go
+++ b/reader/eval/begin.go
@@ -24,16 +24,12 @@ func (b *_begin) Equals(sexp SExpression) bool {
 	return b.TypeId() == sexp.TypeId()
 }
 
-func (_ *_begin) Apply(ctx context.Context, env Environment, args SExpression) (SExpression, error) {
-	arr, err := ToArray(args)
-
-	if err != nil {
-		return nil, err
-	}
+func (_ *_begin) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
 
 	last := NewNil()
+	var err error
 
-	for _, sexp := range arr {
+	for _, sexp := range args {
 		last, err = Eval(ctx, sexp, env)
 		if err != nil {
 			return nil, err

--- a/reader/eval/calc.go
+++ b/reader/eval/calc.go
@@ -27,32 +27,24 @@ func (a *_add) Equals(sexp SExpression) bool {
 	return a.TypeId() == sexp.TypeId()
 }
 
-func (_ *_add) Apply(ctx context.Context, _ Environment, args SExpression) (SExpression, error) {
-	if "cons_cell" != args.TypeId() {
-		return nil, errors.New("need arguments")
-	}
+func (_ *_add) Apply(ctx context.Context, _ Environment, args []SExpression, argsLength uint64) (SExpression, error) {
 
-	if IsEmptyList(args) {
+	if 0 == argsLength {
 		return NewInt(0), nil
 	}
 
-	arr, err := ToArray(args)
-
-	if err != nil {
-		return nil, err
-	}
-	arrIndex := 1
+	arrIndex := uint64(1)
 
 	var result Number = nil
-	if "number" != arr[0].TypeId() {
-		return nil, errors.New("need arguments type is number, but got " + arr[0].TypeId())
+	if "number" != args[0].TypeId() {
+		return nil, errors.New("need arguments type is number, but got " + args[0].TypeId())
 	}
-	result = arr[0].(Number)
-	for ; arrIndex < len(arr); arrIndex++ {
-		if "number" != arr[arrIndex].TypeId() {
-			return nil, errors.New("need arguments type is number, but got " + arr[arrIndex].TypeId())
+	result = args[0].(Number)
+	for ; arrIndex < argsLength; arrIndex++ {
+		if "number" != args[arrIndex].TypeId() {
+			return nil, errors.New("need arguments type is number, but got " + args[arrIndex].TypeId())
 		}
-		result = NewInt(result.GetValue() + arr[arrIndex].(Number).GetValue())
+		result = NewInt(result.GetValue() + args[arrIndex].(Number).GetValue())
 	}
 	return result, nil
 }
@@ -83,32 +75,24 @@ func (a *_minus) Equals(sexp SExpression) bool {
 	return a.TypeId() == sexp.TypeId()
 }
 
-func (_ *_minus) Apply(ctx context.Context, _ Environment, args SExpression) (SExpression, error) {
-	if "cons_cell" != args.TypeId() {
-		return nil, errors.New("need arguments")
+func (_ *_minus) Apply(ctx context.Context, _ Environment, args []SExpression, argsLength uint64) (SExpression, error) {
+
+	if argsLength != 2 {
+		return nil, errors.New("need arguments size is 2")
 	}
 
-	if IsEmptyList(args) {
-		return NewInt(0), nil
-	}
-
-	arr, err := ToArray(args)
-
-	if err != nil {
-		return nil, err
-	}
-	arrIndex := 1
+	arrIndex := uint64(1)
 
 	var result Number = nil
-	if "number" != arr[0].TypeId() {
-		return nil, errors.New("need arguments type is number, but got " + arr[0].TypeId())
+	if "number" != args[0].TypeId() {
+		return nil, errors.New("need arguments type is number, but got " + args[0].TypeId())
 	}
-	result = arr[0].(Number)
-	for ; arrIndex < len(arr); arrIndex++ {
-		if "number" != arr[arrIndex].TypeId() {
-			return nil, errors.New("need arguments type is number, but got " + arr[arrIndex].TypeId())
+	result = args[0].(Number)
+	for ; arrIndex < argsLength; arrIndex++ {
+		if "number" != args[arrIndex].TypeId() {
+			return nil, errors.New("need arguments type is number, but got " + args[arrIndex].TypeId())
 		}
-		result = NewInt(result.GetValue() - arr[arrIndex].(Number).GetValue())
+		result = NewInt(result.GetValue() - args[arrIndex].(Number).GetValue())
 	}
 	return result, nil
 }
@@ -139,28 +123,20 @@ func (a *_multiply) Equals(sexp SExpression) bool {
 	return a.TypeId() == sexp.TypeId()
 }
 
-func (_ *_multiply) Apply(ctx context.Context, _ Environment, args SExpression) (SExpression, error) {
-	if "cons_cell" != args.TypeId() {
-		return nil, errors.New("need arguments")
-	}
+func (_ *_multiply) Apply(ctx context.Context, _ Environment, arr []SExpression, argsLength uint64) (SExpression, error) {
 
-	if IsEmptyList(args) {
+	if 0 == argsLength {
 		return NewInt(0), nil
 	}
 
-	arr, err := ToArray(args)
-
-	if err != nil {
-		return nil, err
-	}
-	arrIndex := 1
+	arrIndex := uint64(1)
 
 	var result Number = nil
 	if "number" != arr[0].TypeId() {
 		return nil, errors.New("need arguments type is number, but got " + arr[0].TypeId())
 	}
 	result = arr[0].(Number)
-	for ; arrIndex < len(arr); arrIndex++ {
+	for ; arrIndex < argsLength; arrIndex++ {
 		if "number" != arr[arrIndex].TypeId() {
 			return nil, errors.New("need arguments type is number, but got " + arr[arrIndex].TypeId())
 		}
@@ -195,28 +171,20 @@ func (a *_divide) Equals(sexp SExpression) bool {
 	return a.TypeId() == sexp.TypeId()
 }
 
-func (_ *_divide) Apply(ctx context.Context, _ Environment, args SExpression) (SExpression, error) {
-	if "cons_cell" != args.TypeId() {
-		return nil, errors.New("need arguments")
+func (_ *_divide) Apply(ctx context.Context, _ Environment, arr []SExpression, argsLength uint64) (SExpression, error) {
+
+	if argsLength != 2 {
+		return nil, errors.New("need arguments size is 2")
 	}
 
-	if IsEmptyList(args) {
-		return NewInt(0), nil
-	}
-
-	arr, err := ToArray(args)
-
-	if err != nil {
-		return nil, err
-	}
-	arrIndex := 1
+	arrIndex := uint64(1)
 
 	var result Number = nil
 	if "number" != arr[0].TypeId() {
 		return nil, errors.New("need arguments type is number, but got " + arr[0].TypeId())
 	}
 	result = arr[0].(Number)
-	for ; arrIndex < len(arr); arrIndex++ {
+	for ; arrIndex < argsLength; arrIndex++ {
 		if "number" != arr[arrIndex].TypeId() {
 			return nil, errors.New("need arguments type is number, but got " + arr[arrIndex].TypeId())
 		}
@@ -251,22 +219,9 @@ func (a *_mod) Equals(sexp SExpression) bool {
 	return a.TypeId() == sexp.TypeId()
 }
 
-func (_ *_mod) Apply(ctx context.Context, _ Environment, args SExpression) (SExpression, error) {
-	if "cons_cell" != args.TypeId() {
-		return nil, errors.New("need arguments")
-	}
+func (_ *_mod) Apply(ctx context.Context, _ Environment, arr []SExpression, argsLength uint64) (SExpression, error) {
 
-	if IsEmptyList(args) {
-		return NewInt(0), nil
-	}
-
-	arr, err := ToArray(args)
-
-	if err != nil {
-		return nil, err
-	}
-
-	if len(arr) != 2 {
+	if argsLength != 2 {
 		return nil, errors.New("need arguments size is 2")
 	}
 

--- a/reader/eval/car.go
+++ b/reader/eval/car.go
@@ -29,13 +29,9 @@ func (l *_car) Equals(sexp SExpression) bool {
 	return l.TypeId() == sexp.TypeId()
 }
 
-func (_ *_car) Apply(ctx context.Context, env Environment, arguments SExpression) (SExpression, error) {
-	args, err := ToArray(arguments)
-	if err != nil {
-		return nil, err
-	}
+func (_ *_car) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
 
-	if 1 > len(args) {
+	if 1 > argsLength {
 		return nil, errors.New("need arguments size is 1")
 	}
 
@@ -44,10 +40,6 @@ func (_ *_car) Apply(ctx context.Context, env Environment, arguments SExpression
 	}
 
 	cons := args[0].(ConsCell)
-
-	if err != nil {
-		return nil, err
-	}
 
 	return cons.GetCar(), nil
 }

--- a/reader/eval/cdr.go
+++ b/reader/eval/cdr.go
@@ -29,13 +29,9 @@ func (l *_cdr) Equals(sexp SExpression) bool {
 	return l.TypeId() == sexp.TypeId()
 }
 
-func (_ *_cdr) Apply(ctx context.Context, env Environment, arguments SExpression) (SExpression, error) {
-	args, err := ToArray(arguments)
-	if err != nil {
-		return nil, err
-	}
+func (_ *_cdr) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
 
-	if 1 > len(args) {
+	if 1 > argsLength {
 		return nil, errors.New("need arguments size is 1")
 	}
 
@@ -44,10 +40,6 @@ func (_ *_cdr) Apply(ctx context.Context, env Environment, arguments SExpression
 	}
 
 	cons := args[0].(ConsCell)
-
-	if err != nil {
-		return nil, err
-	}
 
 	return cons.GetCdr(), nil
 }

--- a/reader/eval/closure.go
+++ b/reader/eval/closure.go
@@ -10,16 +10,16 @@ type _closure struct {
 	body         SExpression
 	formals      []SExpression
 	env          Environment
-	formalsCount int
+	formalsCount uint64
 }
 
 type Closure interface {
 	SExpression
-	GetFormalsCount() int
+	GetFormalsCount() uint64
 	Callable
 }
 
-func NewClosure(body SExpression, formals []SExpression, env Environment, formalsCount int) (Callable, error) {
+func NewClosure(body SExpression, formals []SExpression, env Environment, formalsCount uint64) (Callable, error) {
 	return &_closure{body: body, formals: formals, env: env, formalsCount: formalsCount}, nil
 }
 
@@ -46,19 +46,13 @@ func (c *_closure) Equals(args SExpression) bool {
 	return args.(*_closure) == c
 }
 
-func (c *_closure) GetFormalsCount() int {
+func (c *_closure) GetFormalsCount() uint64 {
 	return c.formalsCount
 }
 
-func (c *_closure) Apply(ctx context.Context, _ Environment, args SExpression) (SExpression, error) {
+func (c *_closure) Apply(ctx context.Context, _ Environment, loopArgs []SExpression, loopArgsLength uint64) (SExpression, error) {
 
-	loopArgs, err := ToArray(args)
-
-	if err != nil {
-		return nil, err
-	}
-
-	if len(loopArgs) != len(c.formals) {
+	if loopArgsLength != c.formalsCount {
 		return nil, errors.New(fmt.Sprintf("not match argument size: %d != %d", len(loopArgs), len(c.formals)))
 	}
 

--- a/reader/eval/current-directory.go
+++ b/reader/eval/current-directory.go
@@ -27,7 +27,7 @@ func (l *_current_directory) Equals(sexp SExpression) bool {
 	return l.TypeId() == sexp.TypeId()
 }
 
-func (_ *_current_directory) Apply(ctx context.Context, env Environment, arguments SExpression) (SExpression, error) {
+func (_ *_current_directory) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
 	p, err := os.Getwd()
 
 	if err != nil {

--- a/reader/eval/define.go
+++ b/reader/eval/define.go
@@ -27,37 +27,28 @@ func (d *_define) Equals(sexp SExpression) bool {
 	return d.TypeId() == sexp.TypeId()
 }
 
-func onSymbolCall(ctx context.Context, env Environment, arguments SExpression) (SExpression, error) {
+func (_ *_define) Apply(ctx context.Context, env Environment, arguments []SExpression, argsLength uint64) (SExpression, error) {
 
-	if "cons_cell" != arguments.TypeId() {
-		return nil, errors.New("type error")
-	}
+	name := arguments[0].(Symbol)
 
-	cell := arguments.(ConsCell)
-
-	name := cell.GetCar().(Symbol)
-
-	if IsEmptyList(cell.GetCdr()) {
+	if argsLength == 1 {
 		env.Define(name, NewNil())
 		return name, nil
 	}
 
-	initValue := cell.GetCdr().(ConsCell)
-
-	if !IsEmptyList(initValue.GetCdr()) {
+	if argsLength != 2 {
 		return nil, errors.New("need less than 3 params")
 	}
-	evaluatedInitValue, err := Eval(ctx, initValue.GetCar(), env)
+
+	initValue := arguments[1]
+
+	evaluatedInitValue, err := Eval(ctx, initValue, env)
 
 	if err != nil {
 		return nil, err
 	}
 	env.Define(name, evaluatedInitValue)
 	return name, nil
-}
-
-func (_ *_define) Apply(ctx context.Context, env Environment, arguments SExpression) (SExpression, error) {
-	return onSymbolCall(ctx, env, arguments)
 }
 
 func NewDefine() SExpression {

--- a/reader/eval/eval.go
+++ b/reader/eval/eval.go
@@ -79,7 +79,7 @@ func evalArgument(ctx context.Context, sexp SExpression, env Environment) ([]SEx
 	}
 
 	if len(cdrEvaluated)+1 < cap(cdrEvaluated) {
-		cdrEvaluated = cdrEvaluated[:len(cdrEvaluated)+1] // slice の延長
+		cdrEvaluated = cdrEvaluated[:len(cdrEvaluated)+2] // slice の延長
 		cdrEvaluated[len(cdrEvaluated)] = carEvaluated
 	} else if cap(cdrEvaluated) < len(cdrEvaluated)+1 {
 		cdrEvaluated = append(cdrEvaluated, carEvaluated)

--- a/reader/eval/eval.go
+++ b/reader/eval/eval.go
@@ -39,22 +39,28 @@ func Eval(ctx context.Context, sexp SExpression, env Environment) (SExpression, 
 			if err != nil {
 				return nil, err
 			}
-			return applied.(Callable).Apply(ctx, env, appliedArgs)
+			return applied.(Callable).Apply(ctx, env, appliedArgs, uint64(len(appliedArgs)))
 		}
 		if SExpressionTypeSpecialForm == appliedType {
-			if err != nil {
+			args, length, toArrErr := ToArray(cell.GetCdr())
+			if toArrErr != nil {
 				return nil, err
 			}
-			return applied.(Callable).Apply(ctx, env, cell.GetCdr())
+			return applied.(Callable).Apply(ctx, env, args, length)
 		}
 
 	}
 	return nil, errors.New("unknown eval: " + sexp.String())
 }
 
-func evalArgument(ctx context.Context, sexp SExpression, env Environment) (SExpression, error) {
+func evalArgument(ctx context.Context, sexp SExpression, env Environment) ([]SExpression, error) {
 	if "cons_cell" != sexp.TypeId() {
-		return Eval(ctx, sexp, env)
+		result, err := Eval(ctx, sexp, env)
+		return []SExpression{result}, err
+	}
+
+	if IsEmptyList(sexp) {
+		return []SExpression{}, nil
 	}
 
 	cell := sexp.(ConsCell)
@@ -69,7 +75,7 @@ func evalArgument(ctx context.Context, sexp SExpression, env Environment) (SExpr
 		return nil, err
 	}
 
-	return NewConsCell(carEvaluated, cdrEvaluated), nil
+	return append([]SExpression{carEvaluated}, cdrEvaluated...), nil
 }
 
 type _eval struct{}
@@ -94,24 +100,19 @@ func (e *_eval) Equals(sexp SExpression) bool {
 	return e.TypeId() == sexp.TypeId()
 }
 
-func (_ *_eval) Apply(ctx context.Context, env Environment, args SExpression) (SExpression, error) {
-	argsArr, err := ToArray(args)
+func (_ *_eval) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
 
-	if err != nil {
-		return nil, err
-	}
-
-	if len(argsArr) != 2 {
+	if argsLength != 2 {
 		return nil, errors.New("malformed eval")
 	}
 
-	targetEnv, err := Eval(ctx, argsArr[1].(Environment), env)
+	targetEnv, err := Eval(ctx, args[1].(Environment), env)
 
 	if err != nil {
 		return nil, err
 	}
 
-	return Eval(ctx, argsArr[0], targetEnv.(Environment))
+	return Eval(ctx, args[0], targetEnv.(Environment))
 }
 
 func NewEval() SExpression {

--- a/reader/eval/garbage-collector.go
+++ b/reader/eval/garbage-collector.go
@@ -27,7 +27,7 @@ func (s *_force_gc) Equals(sexp SExpression) bool {
 	return s.TypeId() == sexp.TypeId()
 }
 
-func (s *_force_gc) Apply(ctx context.Context, env Environment, arguments SExpression) (SExpression, error) {
+func (s *_force_gc) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
 	runtime.GC()
 	return NewBool(true), nil
 }

--- a/reader/eval/get-now-time-micro.go
+++ b/reader/eval/get-now-time-micro.go
@@ -27,7 +27,7 @@ func (l *_get_now_time_nano) Equals(sexp SExpression) bool {
 	return l.TypeId() == sexp.TypeId()
 }
 
-func (_ *_get_now_time_nano) Apply(ctx context.Context, env Environment, args SExpression) (SExpression, error) {
+func (_ *_get_now_time_nano) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
 	return NewInt(time.Now().UnixNano()), nil
 }
 

--- a/reader/eval/global-clear-all.go
+++ b/reader/eval/global-clear-all.go
@@ -24,7 +24,7 @@ func (l *_global_clear_all) Equals(sexp SExpression) bool {
 	return l.TypeId() == sexp.TypeId()
 }
 
-func (_ *_global_clear_all) Apply(ctx context.Context, env Environment, arguments SExpression) (SExpression, error) {
+func (_ *_global_clear_all) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
 	if err := env.GetSuperGlobalEnv().ClearAll(); err != nil {
 		return nil, err
 	}

--- a/reader/eval/global-get-all.go
+++ b/reader/eval/global-get-all.go
@@ -3,7 +3,6 @@ package eval
 import (
 	"bufio"
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 )
@@ -31,16 +30,7 @@ func (l *_global_get_all) Equals(sexp SExpression) bool {
 	return l.TypeId() == sexp.TypeId()
 }
 
-func (_ *_global_get_all) Apply(ctx context.Context, env Environment, args SExpression) (SExpression, error) {
-	if "cons_cell" != args.TypeId() {
-		return nil, errors.New("type error")
-	}
-
-	var err error
-
-	if err != nil {
-		return nil, err
-	}
+func (_ *_global_get_all) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
 
 	res, err := env.GetSuperGlobalEnv().GetAll()
 

--- a/reader/eval/global-get.go
+++ b/reader/eval/global-get.go
@@ -3,7 +3,6 @@ package eval
 import (
 	"bufio"
 	"context"
-	"errors"
 	"fmt"
 	"go.etcd.io/etcd/client/v3/concurrency"
 	"strings"
@@ -32,20 +31,15 @@ func (l *_global_get) Equals(sexp SExpression) bool {
 	return l.TypeId() == sexp.TypeId()
 }
 
-func (_ *_global_get) Apply(ctx context.Context, env Environment, args SExpression) (SExpression, error) {
-	if "cons_cell" != args.TypeId() {
-		return nil, errors.New("type error")
-	}
+func (_ *_global_get) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
 
-	cell := args.(ConsCell)
-
-	name := cell.GetCar().(Symbol)
+	name := args[0].(Symbol)
 
 	defaultArg := (func() SExpression {
-		if IsEmptyList(cell.GetCdr()) {
+		if argsLength == 1 {
 			return NewNil()
 		}
-		return cell.GetCdr().(ConsCell).GetCar()
+		return args[1]
 	})()
 
 	var err error

--- a/reader/eval/global-set.go
+++ b/reader/eval/global-set.go
@@ -30,24 +30,19 @@ func (l *_global_set) Equals(sexp SExpression) bool {
 	return l.TypeId() == sexp.TypeId()
 }
 
-func (_ *_global_set) Apply(ctx context.Context, env Environment, args SExpression) (SExpression, error) {
-	if "cons_cell" != args.TypeId() {
-		return nil, errors.New("type error")
+func (_ *_global_set) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
+
+	if argsLength != 2 {
+		return nil, errors.New("need less than 2 params")
 	}
 
-	cell := args.(ConsCell)
-
-	if cell.GetCar().TypeId() != "symbol" {
+	if args[0].TypeId() != "symbol" {
 		return nil, errors.New("need 1st arguments type is symbol")
 	}
 
-	name := cell.GetCar().(Symbol)
+	name := args[0].(Symbol)
 
-	if IsEmptyList(cell.GetCdr()) {
-		return nil, errors.New("need 3rd arguments")
-	}
-
-	initValue := cell.GetCdr().(ConsCell)
+	initValue := args[1].(ConsCell)
 
 	if !IsEmptyList(initValue.GetCdr()) {
 		return nil, errors.New("need less than 3 params")

--- a/reader/eval/heavy.go
+++ b/reader/eval/heavy.go
@@ -96,12 +96,7 @@ func (h *_heavy) Equals(sexp SExpression) bool {
 	return h.TypeId() == sexp.TypeId()
 }
 
-func (_ *_heavy) Apply(ctx context.Context, env Environment, arguments SExpression) (SExpression, error) {
-	args, err := ToArray(arguments)
-
-	if err != nil {
-		return nil, err
-	}
+func (_ *_heavy) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
 
 	if ctx.Value("transaction") != nil {
 		return nil, errors.New("transaction can not use in heavy")
@@ -114,10 +109,10 @@ func (_ *_heavy) Apply(ctx context.Context, env Environment, arguments SExpressi
 		return nil, err
 	}
 
-	if 1 == len(args) {
+	if 1 == argsLength {
 		SendSExpression(args[0], nil, env, ip, conf.SelfOnCompletePort)
 	}
-	if 2 == len(args) {
+	if 2 == argsLength {
 		SendSExpression(args[0], args[1], env, ip, conf.SelfOnCompletePort)
 	}
 	return nil, err

--- a/reader/eval/if.go
+++ b/reader/eval/if.go
@@ -33,14 +33,9 @@ func (i *_if) Equals(sexp SExpression) bool {
 	return i.TypeId() == sexp.TypeId()
 }
 
-func (_ *_if) Apply(ctx context.Context, env Environment, argument SExpression) (SExpression, error) {
-	args, err := ToArray(argument)
+func (_ *_if) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
 
-	if err != nil {
-		return nil, err
-	}
-
-	if len(args) <= 1 || len(args) >= 4 {
+	if argsLength <= 1 || argsLength >= 4 {
 		return nil, errors.New(fmt.Sprintf("too many argument: %d", len(args)))
 	}
 	argsIndex := 0
@@ -55,7 +50,7 @@ func (_ *_if) Apply(ctx context.Context, env Environment, argument SExpression) 
 	}
 
 	if evaluated.Equals(NewBool(false)) {
-		if len(args) == 2 {
+		if argsLength == 2 {
 			return NewNil(), nil
 		}
 		argsIndex++

--- a/reader/eval/interaction-environment.go
+++ b/reader/eval/interaction-environment.go
@@ -24,7 +24,7 @@ func (i *_get_interaction_environment) Equals(sexp SExpression) bool {
 	return i.TypeId() == sexp.TypeId()
 }
 
-func (_ *_get_interaction_environment) Apply(ctx context.Context, env Environment, args SExpression) (SExpression, error) {
+func (_ *_get_interaction_environment) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
 	return env.GetGlobalEnv(), nil
 }
 

--- a/reader/eval/interface.go
+++ b/reader/eval/interface.go
@@ -4,5 +4,5 @@ import "context"
 
 type Callable interface {
 	SExpression
-	Apply(ctx context.Context, env Environment, args SExpression) (SExpression, error)
+	Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error)
 }

--- a/reader/eval/lambda.go
+++ b/reader/eval/lambda.go
@@ -27,26 +27,22 @@ func (l *_lambda) Equals(sexp SExpression) bool {
 	return l.TypeId() == sexp.TypeId()
 }
 
-func (_ *_lambda) Apply(ctx context.Context, env Environment, arguments SExpression) (SExpression, error) {
-	args, err := ToArray(arguments)
-	if err != nil {
-		return nil, err
-	}
+func (_ *_lambda) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
 
-	if 2 != len(args) {
+	if 2 != argsLength {
 		return nil, errors.New("need arguments size is 2")
 	}
 
 	params := args[0]
 	body := args[1]
 
-	formalsArr, err := ToArray(params)
+	formalsArr, formalsArrLength, err := ToArray(params)
 
 	if err != nil {
 		return nil, err
 	}
 
-	closure, err := NewClosure(body, formalsArr, env, len(formalsArr))
+	closure, err := NewClosure(body, formalsArr, env, formalsArrLength)
 
 	if err != nil {
 		return nil, err

--- a/reader/eval/loop.go
+++ b/reader/eval/loop.go
@@ -28,25 +28,17 @@ func (l *_loop) Equals(sexp SExpression) bool {
 	return l.TypeId() == sexp.TypeId()
 }
 
-func (_ *_loop) Apply(ctx context.Context, env Environment, args SExpression) (SExpression, error) {
-	if "cons_cell" != args.TypeId() {
-		return nil, errors.New("need arguments")
-	}
-	arguments := args.(ConsCell)
-	if !("cons_cell" == arguments.GetCdr().TypeId()) {
-		return nil, errors.New("need arguments")
-	}
-	rawForms := arguments.GetCdr().(ConsCell)
+func (_ *_loop) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
 
-	if !IsEmptyList(rawForms.GetCdr()) {
-		return nil, errors.New("argument size must be 2, but got more than 2 arguments")
+	if argsLength != 2 {
+		return nil, errors.New(fmt.Sprintf("malformed loop: %d", len(args)))
 	}
 
 	var evaluatedCond SExpression
 	var err error
 
 	for {
-		evaluatedCond, err = Eval(ctx, arguments.GetCar(), env)
+		evaluatedCond, err = Eval(ctx, args[0], env)
 		if err != nil {
 			return nil, err
 		}
@@ -59,7 +51,7 @@ func (_ *_loop) Apply(ctx context.Context, env Environment, args SExpression) (S
 			return nil, nil
 		}
 
-		_, err := Eval(ctx, rawForms.GetCar(), env)
+		_, err := Eval(ctx, args[1], env)
 		if err != nil {
 			fmt.Println(err.Error())
 			continue

--- a/reader/eval/native-array.go
+++ b/reader/eval/native-array.go
@@ -61,7 +61,7 @@ func (_ *_new_native_array) Equals(sexp SExpression) bool {
 	return sexp.TypeId() == "subroutine.new-native-array"
 }
 
-func (_ *_new_native_array) Apply(ctx context.Context, env Environment, args SExpression) (SExpression, error) {
+func (_ *_new_native_array) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
 	return &_native_array{
 		Arr: make([]SExpression, 0),
 	}, nil
@@ -93,20 +93,15 @@ func (_ *_get_native_array) Equals(sexp SExpression) bool {
 	return sexp.TypeId() == "subroutine.get-native-array"
 }
 
-func (_ *_get_native_array) Apply(ctx context.Context, env Environment, args SExpression) (SExpression, error) {
-	argsArr, err := ToArray(args)
+func (_ *_get_native_array) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
 
-	if err != nil {
-		return nil, err
-	}
-
-	if 2 != len(argsArr) {
+	if 2 != argsLength {
 		return nil, errors.New("wrong number of arguments")
 	}
 
-	arr := argsArr[0].(*_native_array)
+	arr := args[0].(*_native_array)
 
-	index := argsArr[1].(Number).GetValue()
+	index := args[1].(Number).GetValue()
 
 	if index < 0 || index >= int64(len(arr.Arr)) {
 		return nil, errors.New("index out of range")
@@ -141,28 +136,23 @@ func (_ *_set_native_array) Equals(sexp SExpression) bool {
 	return sexp.TypeId() == "subroutine.set-native-array"
 }
 
-func (_ *_set_native_array) Apply(ctx context.Context, env Environment, args SExpression) (SExpression, error) {
-	argsArr, err := ToArray(args)
+func (_ *_set_native_array) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
 
-	if err != nil {
-		return nil, err
-	}
-
-	if 3 != len(argsArr) {
+	if 3 != len(args) {
 		return nil, errors.New("wrong number of arguments")
 	}
 
-	arr := argsArr[0].(*_native_array)
+	arr := args[0].(*_native_array)
 
-	index := argsArr[1].(Number).GetValue()
+	index := args[1].(Number).GetValue()
 
 	if index < 0 || index >= int64(len(arr.Arr)) {
 		return nil, errors.New("index out of range")
 	}
 
-	arr.Arr[index] = argsArr[2]
+	arr.Arr[index] = args[2]
 
-	return argsArr[2], nil
+	return args[2], nil
 }
 
 func NewSetNativeArray() SExpression {
@@ -191,18 +181,13 @@ func (_ *_length_native_array) Equals(sexp SExpression) bool {
 	return sexp.TypeId() == "subroutine.length-native-array"
 }
 
-func (_ *_length_native_array) Apply(ctx context.Context, env Environment, args SExpression) (SExpression, error) {
-	argsArr, err := ToArray(args)
+func (_ *_length_native_array) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
 
-	if err != nil {
-		return nil, err
-	}
-
-	if 1 != len(argsArr) {
+	if 1 != argsLength {
 		return nil, errors.New("wrong number of arguments")
 	}
 
-	arr := argsArr[0].(*_native_array)
+	arr := args[0].(*_native_array)
 
 	return NewInt(int64(len(arr.Arr))), nil
 }
@@ -233,20 +218,15 @@ func (_ *_append_native_array) Equals(sexp SExpression) bool {
 	return sexp.TypeId() == "subroutine.append-native-array"
 }
 
-func (_ *_append_native_array) Apply(ctx context.Context, env Environment, args SExpression) (SExpression, error) {
-	argsArr, err := ToArray(args)
+func (_ *_append_native_array) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
 
-	if err != nil {
-		return nil, err
-	}
-
-	if 2 != len(argsArr) {
+	if 2 != argsLength {
 		return nil, errors.New("wrong number of arguments")
 	}
 
-	arr := argsArr[0].(*_native_array)
+	arr := args[0].(*_native_array)
 
-	arr.Arr = append(arr.Arr, argsArr[1])
+	arr.Arr = append(arr.Arr, args[1])
 
 	return arr, nil
 }
@@ -277,20 +257,15 @@ func (_ *_native_array_to_list) Equals(sexp SExpression) bool {
 	return sexp.TypeId() == "subroutine.native-array-to-list"
 }
 
-func (_ *_native_array_to_list) Apply(ctx context.Context, env Environment, args SExpression) (SExpression, error) {
-	argsArr, err := ToArray(args)
+func (_ *_native_array_to_list) Apply(ctx context.Context, env Environment, argsArr []SExpression, argsLength uint64) (SExpression, error) {
 
-	if err != nil {
-		return nil, err
-	}
-
-	if 1 != len(argsArr) {
+	if 1 != argsLength {
 		return nil, errors.New("wrong number of arguments")
 	}
 
 	arr := argsArr[0].(*_native_array)
 
-	return ToConsCell(arr.Arr), nil
+	return ToConsCell(arr.Arr, uint64(len(arr.Arr))), nil
 }
 
 func NewNativeArrayToList() SExpression {
@@ -319,18 +294,13 @@ func (_ *_list_to_native_array) Equals(sexp SExpression) bool {
 	return sexp.TypeId() == "subroutine.list-to-native-array"
 }
 
-func (_ *_list_to_native_array) Apply(ctx context.Context, env Environment, args SExpression) (SExpression, error) {
-	argsArr, err := ToArray(args)
+func (_ *_list_to_native_array) Apply(ctx context.Context, env Environment, argsArr []SExpression, argsLength uint64) (SExpression, error) {
 
-	if err != nil {
-		return nil, err
-	}
-
-	if 1 != len(argsArr) {
+	if 1 != argsLength {
 		return nil, errors.New("wrong number of arguments")
 	}
 
-	consCell, err := ToArray(argsArr[0])
+	consCell, _, err := ToArray(argsArr[0])
 
 	if err != nil {
 		return nil, err
@@ -367,13 +337,9 @@ func (l *_foreach_native_array) Equals(sexp SExpression) bool {
 	return l.TypeId() == sexp.TypeId()
 }
 
-func (_ *_foreach_native_array) Apply(ctx context.Context, env Environment, arguments SExpression) (SExpression, error) {
-	args, err := ToArray(arguments)
-	if err != nil {
-		return nil, err
-	}
+func (_ *_foreach_native_array) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
 
-	if 2 > len(args) {
+	if 2 > argsLength {
 		return nil, errors.New("need arguments size is 2")
 	}
 
@@ -400,14 +366,8 @@ func (_ *_foreach_native_array) Apply(ctx context.Context, env Environment, argu
 	}
 
 	if lambda.GetFormalsCount() == 2 {
-		var argsSexp = _cons_cell{
-			Car: NewNil(),
-			Cdr: NewNil(),
-		}
 		for i, v := range nativeArray.(*_native_array).Arr {
-			argsSexp.Car = NewInt(int64(i))
-			argsSexp.Cdr = NewConsCell(v, NewNil())
-			_, err := lambda.Apply(ctx, env, &argsSexp)
+			_, err := lambda.Apply(ctx, env, []SExpression{NewInt(int64(i)), v}, 2)
 
 			if err != nil {
 				return nil, err
@@ -415,17 +375,8 @@ func (_ *_foreach_native_array) Apply(ctx context.Context, env Environment, argu
 		}
 		return NewNil(), nil
 	} else {
-		var childArgsSexp = _cons_cell{
-			Car: NewNil(),
-			Cdr: NewNil(),
-		}
-		var argsSexp = _cons_cell{
-			Car: NewNil(),
-			Cdr: &childArgsSexp,
-		}
 		for _, v := range nativeArray.(*_native_array).Arr {
-			argsSexp.Car = v
-			_, err := lambda.Apply(ctx, env, &argsSexp)
+			_, err := lambda.Apply(ctx, env, []SExpression{v}, 1)
 
 			if err != nil {
 				return nil, err

--- a/reader/eval/native-hashmap.go
+++ b/reader/eval/native-hashmap.go
@@ -61,7 +61,7 @@ func (l *_new_native_hashmap) Equals(sexp SExpression) bool {
 	return l.TypeId() == sexp.TypeId()
 }
 
-func (_ *_new_native_hashmap) Apply(ctx context.Context, env Environment, arguments SExpression) (SExpression, error) {
+func (_ *_new_native_hashmap) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
 	return &_native_hashmap{
 		id: uuid.NewString(),
 		M:  make(map[string]SExpression),
@@ -94,13 +94,9 @@ func (l *_put_native_hashmap) Equals(sexp SExpression) bool {
 	return l.TypeId() == sexp.TypeId()
 }
 
-func (_ *_put_native_hashmap) Apply(ctx context.Context, env Environment, arguments SExpression) (SExpression, error) {
-	args, err := ToArray(arguments)
-	if err != nil {
-		return nil, err
-	}
+func (_ *_put_native_hashmap) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
 
-	if 3 > len(args) {
+	if 3 > argsLength {
 		return nil, errors.New("need arguments size is 3")
 	}
 
@@ -145,13 +141,9 @@ func (l *_get_native_hashmap) Equals(sexp SExpression) bool {
 	return l.TypeId() == sexp.TypeId()
 }
 
-func (_ *_get_native_hashmap) Apply(ctx context.Context, env Environment, arguments SExpression) (SExpression, error) {
-	args, err := ToArray(arguments)
-	if err != nil {
-		return nil, err
-	}
+func (_ *_get_native_hashmap) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
 
-	if 2 > len(args) {
+	if 2 > argsLength {
 		return nil, errors.New("need arguments size is 2")
 	}
 
@@ -203,13 +195,9 @@ func (l *_key_value_pair_foreach_native_hashmap) Equals(sexp SExpression) bool {
 	return l.TypeId() == sexp.TypeId()
 }
 
-func (_ *_key_value_pair_foreach_native_hashmap) Apply(ctx context.Context, env Environment, arguments SExpression) (SExpression, error) {
-	args, err := ToArray(arguments)
-	if err != nil {
-		return nil, err
-	}
+func (_ *_key_value_pair_foreach_native_hashmap) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
 
-	if 2 > len(args) {
+	if 2 > argsLength {
 		return nil, errors.New("need arguments size is 2")
 	}
 
@@ -264,13 +252,9 @@ func (l *_key_value_pair_native_hashmap_to_cons_cell) Equals(sexp SExpression) b
 	return l.TypeId() == sexp.TypeId()
 }
 
-func (_ *_key_value_pair_native_hashmap_to_cons_cell) Apply(ctx context.Context, env Environment, arguments SExpression) (SExpression, error) {
-	args, err := ToArray(arguments)
-	if err != nil {
-		return nil, err
-	}
+func (_ *_key_value_pair_native_hashmap_to_cons_cell) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
 
-	if 1 > len(args) {
+	if 1 > argsLength {
 		return nil, errors.New("need arguments size is 1")
 	}
 

--- a/reader/eval/not.go
+++ b/reader/eval/not.go
@@ -28,13 +28,13 @@ func (i *_is_not) Equals(sexp SExpression) bool {
 	return i.TypeId() == sexp.TypeId()
 }
 
-func (_ *_is_not) Apply(ctx context.Context, env Environment, arguments SExpression) (SExpression, error) {
-	if "cons_cell" != arguments.TypeId() {
-		return nil, errors.New("type error")
-	}
-	argCell := arguments.(ConsCell)
+func (_ *_is_not) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
 
-	first := argCell.GetCar()
+	if argsLength != 1 {
+		return nil, errors.New("malformed not")
+	}
+
+	first := args[0]
 
 	if "bool" != first.TypeId() {
 		return first, nil

--- a/reader/eval/or.go
+++ b/reader/eval/or.go
@@ -25,22 +25,13 @@ func (a _or) Equals(sexp SExpression) bool {
 	return a.TypeId() == sexp.TypeId()
 }
 
-func (_ _or) Apply(ctx context.Context, env Environment, args SExpression) (SExpression, error) {
-
-	if IsEmptyList(args) {
-		return NewBool(false), nil
-	}
-
-	arr, err := ToArray(args)
-
-	if err != nil {
-		return nil, err
-	}
+func (_ _or) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
 
 	evaluatedElm := NewConsCell(NewNil(), NewNil()).(SExpression)
+	var err error
 
-	for i := 0; i < len(arr); i++ {
-		evaluatedElm, err = Eval(ctx, arr[i], env)
+	for i := uint64(0); i < argsLength; i++ {
+		evaluatedElm, err = Eval(ctx, args[i], env)
 		if err != nil {
 			return nil, err
 		}

--- a/reader/eval/print.go
+++ b/reader/eval/print.go
@@ -28,15 +28,11 @@ func (p *_print) Equals(sexp SExpression) bool {
 	return p.TypeId() == sexp.TypeId()
 }
 
-func (_ *_print) Apply(ctx context.Context, env Environment, args SExpression) (SExpression, error) {
-	arr, err := ToArray(args)
-	if err != nil {
-		return nil, err
-	}
-	if len(arr) != 1 {
+func (_ *_print) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
+	if argsLength != 1 {
 		return nil, errors.New("need args size is 1")
 	}
-	fmt.Print(arr[0])
+	fmt.Print(args[0])
 	return NewNil(), nil
 }
 

--- a/reader/eval/println.go
+++ b/reader/eval/println.go
@@ -28,18 +28,14 @@ func (p *_println) Equals(sexp SExpression) bool {
 	return p.TypeId() == sexp.TypeId()
 }
 
-func (_ *_println) Apply(ctx context.Context, env Environment, args SExpression) (SExpression, error) {
-	arr, err := ToArray(args)
-	if err != nil {
-		return nil, err
-	}
-	if len(arr) < 1 {
+func (_ *_println) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
+	if argsLength < 1 {
 		return nil, errors.New("need args size is 1")
 	}
 
-	for i := 0; i < len(arr); i++ {
-		fmt.Print(arr[i])
-		if i+1 == len(arr) {
+	for i := uint64(0); i < argsLength; i++ {
+		fmt.Print(args[i])
+		if i+1 == argsLength {
 			fmt.Println()
 			break
 		}

--- a/reader/eval/quasiquote.go
+++ b/reader/eval/quasiquote.go
@@ -96,16 +96,11 @@ func _innerEvalQuasiquote(ctx context.Context, env Environment, x SExpression) (
 }
 
 // this function is lisp interpter function for quasiquote
-func (_ *_quasiquote) Apply(ctx context.Context, env Environment, args SExpression) (SExpression, error) {
-	arr, err := ToArray(args)
-
-	if err != nil {
-		return nil, err
-	}
-	if len(arr) != 1 {
+func (_ *_quasiquote) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
+	if argsLength != 1 {
 		return nil, errors.New("malformed quote")
 	}
-	return _innerEvalQuasiquote(ctx, env, arr[0])
+	return _innerEvalQuasiquote(ctx, env, args[0])
 }
 
 func NewQuasiquote() SExpression {

--- a/reader/eval/quote.go
+++ b/reader/eval/quote.go
@@ -27,16 +27,11 @@ func (q *_quote) Equals(sexp SExpression) bool {
 	return q.TypeId() == sexp.TypeId()
 }
 
-func (_ *_quote) Apply(ctx context.Context, env Environment, args SExpression) (SExpression, error) {
-	arr, err := ToArray(args)
-
-	if err != nil {
-		return nil, err
-	}
-	if len(arr) != 1 {
+func (_ *_quote) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
+	if argsLength != 1 {
 		return nil, errors.New("malformed quote")
 	}
-	return arr[0], nil
+	return args[0], nil
 }
 
 func NewQuote() SExpression {

--- a/reader/eval/read-file.go
+++ b/reader/eval/read-file.go
@@ -28,14 +28,8 @@ func (l *_file_read) Equals(sexp SExpression) bool {
 	return l.TypeId() == sexp.TypeId()
 }
 
-func (_ *_file_read) Apply(ctx context.Context, env Environment, arguments SExpression) (SExpression, error) {
-
-	args, err := ToArray(arguments)
-	if err != nil {
-		return nil, err
-	}
-
-	if 1 > len(args) {
+func (_ *_file_read) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
+	if 1 > argsLength {
 		return nil, errors.New("need arguments size is 1")
 	}
 

--- a/reader/eval/read-line-file.go
+++ b/reader/eval/read-line-file.go
@@ -29,16 +29,12 @@ func (l *_file_read_line) Equals(sexp SExpression) bool {
 	return l.TypeId() == sexp.TypeId()
 }
 
-func (_ *_file_read_line) Apply(ctx context.Context, env Environment, arguments SExpression) (SExpression, error) {
+func (_ *_file_read_line) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
 	// 1st filepath string
 	// 2nd on-load-line function
 	// 3rd on-load-end function
-	args, err := ToArray(arguments)
-	if err != nil {
-		return nil, err
-	}
 
-	if 2 > len(args) {
+	if 2 > argsLength {
 		return nil, errors.New("need arguments size is 1")
 	}
 
@@ -53,7 +49,7 @@ func (_ *_file_read_line) Apply(ctx context.Context, env Environment, arguments 
 
 	var fp *os.File
 
-	fp, err = os.Open(path)
+	fp, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}

--- a/reader/eval/set.go
+++ b/reader/eval/set.go
@@ -27,25 +27,15 @@ func (s *_set) Equals(sexp SExpression) bool {
 	return s.TypeId() == sexp.TypeId()
 }
 
-func (_ *_set) Apply(ctx context.Context, env Environment, arguments SExpression) (SExpression, error) {
-	if "cons_cell" != arguments.TypeId() {
-		return nil, errors.New("type error")
+func (_ *_set) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
+
+	if argsLength != 2 {
+		return nil, errors.New("malformed set")
 	}
 
-	cell := arguments.(ConsCell)
+	name := args[0].(Symbol)
 
-	name := cell.GetCar().(Symbol)
-
-	if IsEmptyList(cell.GetCdr()) {
-		return nil, errors.New("need 3rd arguments")
-	}
-
-	initValue := cell.GetCdr().(ConsCell)
-
-	if !IsEmptyList(initValue.GetCdr()) {
-		return nil, errors.New("need less than 3 params")
-	}
-	evaluatedInitValue, err := Eval(ctx, initValue.GetCar(), env)
+	evaluatedInitValue, err := Eval(ctx, args[1], env)
 
 	if err != nil {
 		return nil, err

--- a/reader/eval/sexp.go
+++ b/reader/eval/sexp.go
@@ -326,18 +326,19 @@ func (cell *_cons_cell) String() string {
 	return joinedString.String()
 }
 
-func ToArray(sexp SExpression) ([]SExpression, error) {
+func ToArray(sexp SExpression) ([]SExpression, uint64, error) {
 	list := make([]SExpression, 0, 0)
 	look := sexp
 	var tail SExpression
 	var tailCell ConsCell
+	var count = uint64(0)
 	for {
 		if SExpressionTypeConsCell != look.SExpressionTypeId() {
-			return nil, errors.New("need list")
+			return nil, 0, errors.New("need list")
 		}
 		tail = look.(ConsCell)
 		if SExpressionTypeConsCell != tail.SExpressionTypeId() {
-			return nil, errors.New("need list")
+			return nil, 0, errors.New("need list")
 		}
 		tailCell = tail.(ConsCell)
 		if SExpressionTypeNil == tailCell.GetCar().SExpressionTypeId() && SExpressionTypeNil == tailCell.GetCdr().SExpressionTypeId() {
@@ -345,8 +346,9 @@ func ToArray(sexp SExpression) ([]SExpression, error) {
 		}
 		list = append(list, look.(ConsCell).GetCar())
 		look = look.(ConsCell).GetCdr()
+		count++
 	}
-	return list, nil
+	return list, count, nil
 }
 
 func (cell *_cons_cell) IsList() bool {
@@ -367,21 +369,20 @@ func (cell *_cons_cell) GetCdr() SExpression {
 	return cell.Cdr
 }
 
-func ToConsCell(list []SExpression) ConsCell {
-	var head = (NewConsCell(NewNil(), NewNil())).(*_cons_cell)
-	var look = head
-	var beforeLook *_cons_cell = nil
+func ToConsCell(list []SExpression, argsLength uint64) ConsCell {
+	var cells = make([]_cons_cell, argsLength+1)
+	var look = &cells[0]
 
-	for _, sexp := range list {
+	for i, sexp := range list {
 		look.Car = sexp
-		look.Cdr = NewConsCell(NewNil(), NewNil())
-		beforeLook = look
+		look.Cdr = &(cells[i+1])
+		if uint64(i) == argsLength-1 {
+			look.Cdr = NewConsCell(NewNil(), NewNil())
+		}
 		look = (look.Cdr).(*_cons_cell)
 	}
-	if beforeLook != nil {
-		beforeLook.Cdr = NewConsCell(NewNil(), NewNil())
-	}
-	return head
+
+	return &cells[0]
 }
 
 func IsEmptyList(list SExpression) bool {

--- a/reader/eval/string-append.go
+++ b/reader/eval/string-append.go
@@ -27,21 +27,17 @@ func (s *_string_append) Equals(sexp SExpression) bool {
 	return s.TypeId() == sexp.TypeId()
 }
 
-func (_ *_string_append) Apply(ctx context.Context, env Environment, args SExpression) (SExpression, error) {
-	arr, err := ToArray(args)
-	if err != nil {
-		return nil, err
-	}
-	if len(arr) < 1 {
+func (_ *_string_append) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
+	if argsLength < 1 {
 		return nil, errors.New("need args size is 1")
 	}
 
 	var str string
-	for i := 0; i < len(arr); i++ {
-		if "string" != arr[i].TypeId() {
-			return nil, errors.New("need args type is string, but got " + arr[i].TypeId())
+	for i := uint64(0); i < argsLength; i++ {
+		if "string" != args[i].TypeId() {
+			return nil, errors.New("need args type is string, but got " + args[i].TypeId())
 		}
-		str += arr[i].(Str).GetValue()
+		str += args[i].(Str).GetValue()
 	}
 	return NewString(str), nil
 }

--- a/reader/eval/string-len.go
+++ b/reader/eval/string-len.go
@@ -28,16 +28,13 @@ func (s *_string_len) Equals(sexp SExpression) bool {
 	return s.TypeId() == sexp.TypeId()
 }
 
-func (_ *_string_len) Apply(ctx context.Context, env Environment, args SExpression) (SExpression, error) {
-	arr, err := ToArray(args)
-	if err != nil {
-		return nil, err
-	}
-	if len(arr) != 1 {
+func (_ *_string_len) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
+
+	if argsLength != 1 {
 		return nil, errors.New("need args size is 1")
 	}
 
-	size := int64(utf8.RuneCountInString(arr[0].(Str).GetValue()))
+	size := int64(utf8.RuneCountInString(args[0].(Str).GetValue()))
 
 	return NewInt(size), nil
 }

--- a/reader/eval/string-split.go
+++ b/reader/eval/string-split.go
@@ -28,27 +28,23 @@ func (s *_string_split) Equals(sexp SExpression) bool {
 	return s.TypeId() == sexp.TypeId()
 }
 
-func (_ *_string_split) Apply(ctx context.Context, env Environment, args SExpression) (SExpression, error) {
-	arr, err := ToArray(args)
-	if err != nil {
-		return nil, err
-	}
-	if len(arr) < 1 {
+func (_ *_string_split) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
+	if argsLength < 1 {
 		return nil, errors.New("need args size is 1")
 	}
 
-	if arr[0].TypeId() != "string" {
+	if args[0].TypeId() != "string" {
 		return nil, errors.New("need args type is string")
 	}
 
-	str := arr[0].(Str).GetValue()
+	str := args[0].(Str).GetValue()
 
 	var sep string
-	if len(arr) == 2 {
-		if arr[1].TypeId() != "string" {
+	if argsLength == 2 {
+		if args[1].TypeId() != "string" {
 			return nil, errors.New("need args type is string")
 		}
-		sep = arr[1].(Str).GetValue()
+		sep = args[1].(Str).GetValue()
 	} else {
 		sep = ""
 	}

--- a/reader/eval/stringtosymbol.go
+++ b/reader/eval/stringtosymbol.go
@@ -7,21 +7,17 @@ import (
 
 type _string_to_symbol struct{}
 
-func (s *_string_to_symbol) Apply(ctx context.Context, env Environment, args SExpression) (SExpression, error) {
-	arr, err := ToArray(args)
-	if err != nil {
-		return nil, err
-	}
+func (s *_string_to_symbol) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
 
-	if 1 != len(arr) {
+	if 1 != argsLength {
 		return nil, errors.New("need arguments size is 1")
 	}
 
-	if "string" != arr[0].TypeId() {
-		return nil, errors.New("need arguments type is string, but got " + arr[0].TypeId())
+	if "string" != args[0].TypeId() {
+		return nil, errors.New("need arguments type is string, but got " + args[0].TypeId())
 	}
 
-	return NewSymbol(arr[0].(Str).GetValue()), nil
+	return NewSymbol(args[0].(Str).GetValue()), nil
 }
 
 func (s *_string_to_symbol) TypeId() string {

--- a/reader/eval/symbol-name.go
+++ b/reader/eval/symbol-name.go
@@ -7,21 +7,17 @@ import (
 
 type _symbol_name struct{}
 
-func (s *_symbol_name) Apply(ctx context.Context, env Environment, args SExpression) (SExpression, error) {
-	arr, err := ToArray(args)
-	if err != nil {
-		return nil, err
-	}
+func (s *_symbol_name) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
 
-	if 1 != len(arr) {
+	if 1 != argsLength {
 		return nil, errors.New("need arguments size is 1")
 	}
 
-	if "symbol" != arr[0].TypeId() {
-		return nil, errors.New("need arguments type is symbol, but got " + arr[0].TypeId())
+	if "symbol" != args[0].TypeId() {
+		return nil, errors.New("need arguments type is symbol, but got " + args[0].TypeId())
 	}
 
-	return NewString(arr[0].(Symbol).GetValue()), nil
+	return NewString(args[0].(Symbol).GetValue()), nil
 }
 
 func (s *_symbol_name) TypeId() string {

--- a/reader/eval/this-environment.go
+++ b/reader/eval/this-environment.go
@@ -24,7 +24,7 @@ func (i *_this_environment) Equals(sexp SExpression) bool {
 	return i.TypeId() == sexp.TypeId()
 }
 
-func (_ *_this_environment) Apply(ctx context.Context, env Environment, args SExpression) (SExpression, error) {
+func (_ *_this_environment) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
 	return env, nil
 }
 

--- a/reader/eval/to_string.go
+++ b/reader/eval/to_string.go
@@ -7,19 +7,13 @@ import (
 
 type _to_string struct{}
 
-func (s *_to_string) Apply(ctx context.Context, env Environment, args SExpression) (SExpression, error) {
+func (s *_to_string) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
 
-	arr, err := ToArray(args)
-
-	if err != nil {
-		return nil, err
-	}
-
-	if len(arr) != 1 {
+	if argsLength != 1 {
 		return nil, errors.New("need arguments size is 1")
 	}
 
-	return NewString(arr[0].String()), nil
+	return NewString(args[0].String()), nil
 }
 
 func (s *_to_string) TypeId() string {

--- a/reader/eval/transcation.go
+++ b/reader/eval/transcation.go
@@ -2,7 +2,6 @@ package eval
 
 import (
 	"context"
-	"errors"
 	"go.etcd.io/etcd/client/v3/concurrency"
 )
 
@@ -28,20 +27,10 @@ func (t *_transaction) Equals(sexp SExpression) bool {
 	return t.TypeId() == sexp.TypeId()
 }
 
-func (_ *_transaction) Apply(ctx context.Context, env Environment, args SExpression) (SExpression, error) {
-
-	if "cons_cell" != args.TypeId() {
-		return nil, errors.New("type error")
-	}
-
-	cell := args.(ConsCell)
-
-	if !IsEmptyList(cell.GetCdr()) {
-		return nil, errors.New("need less than 2 params")
-	}
+func (_ *_transaction) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
 
 	ok, err := env.GetSuperGlobalEnv().Transaction(func(stm concurrency.STM) error {
-		_, err := Eval(context.WithValue(ctx, "transaction", stm), cell.GetCar(), env)
+		_, err := Eval(context.WithValue(ctx, "transaction", stm), args[0], env)
 		if err != nil {
 			return err
 		}

--- a/reader/eval/void.go
+++ b/reader/eval/void.go
@@ -27,18 +27,13 @@ func (l *_void) Equals(sexp SExpression) bool {
 	return l.TypeId() == sexp.TypeId()
 }
 
-func (_ *_void) Apply(ctx context.Context, env Environment, arguments SExpression) (SExpression, error) {
-	args, err := ToArray(arguments)
+func (_ *_void) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
 
-	if err != nil {
-		return nil, err
-	}
-
-	if 1 != len(args) {
+	if 1 != argsLength {
 		return nil, errors.New("need arguments size is 1")
 	}
 
-	_, err = Eval(ctx, args[0], env)
+	_, err := Eval(ctx, args[0], env)
 
 	if err != nil {
 		return nil, err

--- a/reader/eval/wait.go
+++ b/reader/eval/wait.go
@@ -28,17 +28,9 @@ func (l *_wait) Equals(sexp SExpression) bool {
 	return l.TypeId() == sexp.TypeId()
 }
 
-func (_ *_wait) Apply(ctx context.Context, env Environment, args SExpression) (SExpression, error) {
-	if "cons_cell" != args.TypeId() {
-		return nil, errors.New("need arguments")
-	}
-	arguments := args.(ConsCell)
+func (_ *_wait) Apply(ctx context.Context, env Environment, args []SExpression, argsLength uint64) (SExpression, error) {
 
-	if !IsEmptyList(arguments.GetCdr()) {
-		return nil, errors.New("need arguments length is 1")
-	}
-
-	waitTime, err := Eval(ctx, arguments.GetCar(), env)
+	waitTime, err := Eval(ctx, args[0], env)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## やったこと
- Lisp定義的なS式表現をGoネイティブの配列表現で取り扱うようにした
- ConsCellの必要数が事前にわかっている場合、配列としてまとめて確保するようにした